### PR TITLE
Missing outputs

### DIFF
--- a/circom-compat/src/R1CS/Circom.hs
+++ b/circom-compat/src/R1CS/Circom.hs
@@ -27,6 +27,7 @@ import Data.IntSet qualified as IntSet
 import Data.Vector (Vector)
 import Data.Vector qualified as V
 import Protolude
+import Circuit (CircuitVars(..))
 import R1CS (LinearPoly (..), R1C (..), R1CS (..), Witness (..))
 import Prelude (fail)
 
@@ -92,17 +93,17 @@ r1csFromCircomR1CS (CircomR1CS {..}) =
           end = start + fromIntegral (rhNPrvIn crHeader)
        in (start, end)
 
-circomReindexMap :: R1CS f -> IntMap Int
-circomReindexMap R1CS {..} =
+circomReindexMap :: CircuitVars label -> IntMap Int
+circomReindexMap CircuitVars {..} =
   let importantVars =
         concat
-          [ r1csOutputs,
-            r1csPublicInputs,
-            r1csPrivateInputs
+          [ IntSet.toAscList cvOutputs,
+            IntSet.toAscList cvPublicInputs,
+            IntSet.toAscList cvPrivateInputs
           ]
       otherVars =
         let s = IntSet.fromList importantVars
-         in filter (\v -> not $ v `IntSet.member` s) [1 .. r1csNumVars]
+         in IntSet.toAscList $ cvVars IntSet.\\ s
    in IntMap.fromList $ zip (importantVars <> otherVars) [1 ..]
 
 newtype CircomR1CSBuilder k = CircomR1CSBuilder (CircomR1CS k -> CircomR1CS k)

--- a/circom-compat/src/R1CS/Circom.hs
+++ b/circom-compat/src/R1CS/Circom.hs
@@ -10,6 +10,7 @@ module R1CS.Circom
     witnessFromCircomWitness,
     FieldSize (..),
     n32,
+    circomReindexMap,
     -- for testing
     integerFromLittleEndian,
     integerToLittleEndian,
@@ -22,6 +23,7 @@ import Data.Binary.Put (putInt32le, putLazyByteString, putWord32le, putWord64le,
 import Data.ByteString.Lazy qualified as LBS
 import Data.Field.Galois (GaloisField (char), PrimeField, fromP)
 import Data.IntMap qualified as IntMap
+import Data.IntSet qualified as IntSet
 import Data.Vector (Vector)
 import Data.Vector qualified as V
 import Protolude
@@ -54,9 +56,9 @@ r1csToCircomR1CS R1CS {..} =
           { rhFieldSize = FieldSize 32,
             rhPrime = fromIntegral $ char (1 :: f),
             rhNVars = fromIntegral r1csNumVars,
-            rhNPubOut = fromIntegral r1csNumOutputs,
-            rhNPubIn = fromIntegral r1csNumPublicInputs,
-            rhNPrvIn = fromIntegral r1csNumPrivateInputs,
+            rhNPubOut = fromIntegral $ length r1csOutputs,
+            rhNPubIn = fromIntegral $ length r1csPublicInputs,
+            rhNPrvIn = fromIntegral $ length r1csPrivateInputs,
             -- I'm not sure what a label is, but i doubt we're using it
             rhNLabels = 0,
             rhNConstraints = fromIntegral $ length r1csConstraints
@@ -71,10 +73,37 @@ r1csFromCircomR1CS (CircomR1CS {..}) =
   R1CS
     { r1csConstraints = crConstraints,
       r1csNumVars = fromIntegral $ rhNVars crHeader,
-      r1csNumPublicInputs = fromIntegral $ rhNPubIn crHeader,
-      r1csNumPrivateInputs = fromIntegral $ rhNPrvIn crHeader,
-      r1csNumOutputs = fromIntegral $ rhNPubOut crHeader
+      r1csPublicInputs = [fst pubVars .. snd pubVars],
+      r1csPrivateInputs = [fst privVars .. snd privVars],
+      r1csOutputs = [fst outputVars .. snd outputVars]
     }
+  where
+    -- circom variables follow this convention
+    outputVars =
+      let start = 1 :: Int
+          end = fromIntegral $ rhNPubOut crHeader
+       in (start, end)
+    pubVars =
+      let start = snd outputVars + 1
+          end = start + fromIntegral (rhNPubIn crHeader)
+       in (start, end)
+    privVars =
+      let start = snd pubVars + 1
+          end = start + fromIntegral (rhNPrvIn crHeader)
+       in (start, end)
+
+circomReindexMap :: R1CS f -> IntMap Int
+circomReindexMap R1CS {..} =
+  let importantVars =
+        concat
+          [ r1csOutputs,
+            r1csPublicInputs,
+            r1csPrivateInputs
+          ]
+      otherVars =
+        let s = IntSet.fromList importantVars
+         in filter (\v -> not $ v `IntSet.member` s) [1 .. r1csNumVars]
+   in IntMap.fromList $ zip (importantVars <> otherVars) [1 ..]
 
 newtype CircomR1CSBuilder k = CircomR1CSBuilder (CircomR1CS k -> CircomR1CS k)
 

--- a/circuit/src/Circuit/Arithmetic.hs
+++ b/circuit/src/Circuit/Arithmetic.hs
@@ -12,7 +12,6 @@ module Circuit.Arithmetic
     evalGate,
     evalArithCircuit,
     unsplit,
-    reindex,
     CircuitVars (..),
     relabel,
     collectCircuitVars,
@@ -22,6 +21,7 @@ module Circuit.Arithmetic
     nGates,
     InputBidings (..),
     insertInputBinding,
+    Reindexable (..),
   )
 where
 
@@ -278,13 +278,6 @@ unsplit ::
   AffineCircuit f Wire
 unsplit = snd . foldl (\(ix, rest) wire -> (ix + (1 :: Integer), Add rest (ScalarMul (2 ^ ix) (Var wire)))) (0, ConstGate 0)
 
-reindex :: (Int -> Int) -> ArithCircuit f -> ArithCircuit f
-reindex f (ArithCircuit gates) = ArithCircuit $ map (second $ mapWire f) gates
-  where
-    mapWire g (InputWire l t v) = InputWire l t (g v)
-    mapWire g (IntermediateWire v) = IntermediateWire (g v)
-    mapWire g (OutputWire v) = OutputWire (g v)
-
 data CircuitVars label = CircuitVars
   { cvVars :: IntSet,
     cvPrivateInputs :: IntSet,
@@ -411,3 +404,30 @@ insertInputBinding label var InputBidings {..} =
 
 inputBindingsFromList :: (Ord label) => [(label, Int)] -> InputBidings label
 inputBindingsFromList = foldl' (flip $ uncurry insertInputBinding) mempty
+
+--------------------------------------------------------------------------------
+
+class Reindexable a where
+  reindex :: IntMap Int -> a -> a
+
+instance Reindexable Wire where
+  reindex f = \case
+    InputWire l t i -> InputWire l t (g i)
+    IntermediateWire i -> IntermediateWire (g i)
+    OutputWire i -> OutputWire (g i)
+    where
+      g i = fromMaybe i $ IntMap.lookup i f
+
+instance Reindexable (AffineCircuit f Wire) where
+  reindex f (Add l r) = Add (reindex f l) (reindex f r)
+  reindex f (Var i) = Var $ reindex f i
+  reindex _ a = a
+
+instance Reindexable (Gate f Wire) where
+  reindex f (Mul l r o) = Mul (reindex f l) (reindex f r) (reindex f o)
+  reindex f (Equal i m o) = Equal (reindex f i) (reindex f m) (reindex f o)
+  reindex f (Split i os) = Split (reindex f i) (reindex f <$> os)
+  reindex f (Boolean i) = Boolean (reindex f i)
+
+instance Reindexable (ArithCircuit f) where
+  reindex f (ArithCircuit gs) = ArithCircuit (reindex f <$> gs)

--- a/circuit/src/R1CS.hs
+++ b/circuit/src/R1CS.hs
@@ -9,7 +9,6 @@ module R1CS
     validateWitness,
     isValidWitness,
     calculateWitness,
-    Reindexable (..),
   )
 where
 

--- a/circuit/src/R1CS.hs
+++ b/circuit/src/R1CS.hs
@@ -9,10 +9,11 @@ module R1CS
     validateWitness,
     isValidWitness,
     calculateWitness,
+    Reindexable (..),
   )
 where
 
-import Circuit (AffineCircuit (..), ArithCircuit (..), CircuitVars (..), Gate (..), Wire (..), solve, unsplit, wireName)
+import Circuit (AffineCircuit (..), ArithCircuit (..), CircuitVars (..), Gate (..), Reindexable (..), Wire (..), solve, unsplit, wireName)
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Field.Galois (PrimeField)
 import Data.IntMap qualified as IntMap
@@ -98,9 +99,9 @@ mkR1C = \case
 data R1CS f = R1CS
   { r1csConstraints :: [R1C f],
     r1csNumVars :: Int,
-    r1csNumPublicInputs :: Int,
-    r1csNumPrivateInputs :: Int,
-    r1csNumOutputs :: Int
+    r1csPublicInputs :: [Int],
+    r1csPrivateInputs :: [Int],
+    r1csOutputs :: [Int]
   }
   deriving (Show)
 
@@ -146,9 +147,9 @@ toR1CS CircuitVars {..} (ArithCircuit gates) =
   R1CS
     { r1csConstraints = mkR1C <$> gates,
       r1csNumVars = IntSet.size $ IntSet.insert oneVar cvVars,
-      r1csNumPublicInputs = IntSet.size cvPublicInputs,
-      r1csNumPrivateInputs = IntSet.size cvPrivateInputs,
-      r1csNumOutputs = IntSet.size cvOutputs
+      r1csPublicInputs = IntSet.toList cvPublicInputs,
+      r1csPrivateInputs = IntSet.toList cvPrivateInputs,
+      r1csOutputs = IntSet.toList cvOutputs
     }
 
 calculateWitness ::
@@ -162,3 +163,27 @@ calculateWitness vars circuit (Inputs m) =
   let r1cs = toR1CS vars circuit
       w = solve vars circuit (IntMap.insert oneVar 1 m)
    in (r1cs, Witness w)
+
+--------------------------------------------------------------------------------
+
+instance Reindexable (LinearPoly f) where
+  reindex f (LinearPoly p) = LinearPoly $ IntMap.compose p f
+
+instance Reindexable (Witness f) where
+  reindex f (Witness w) = Witness $ IntMap.compose w f
+
+instance Reindexable (R1C f) where
+  reindex f (R1C (a, b, c)) =
+    R1C (reindex f a, reindex f b, reindex f c)
+
+instance Reindexable (R1CS f) where
+  reindex f R1CS {..} =
+    R1CS
+      { r1csConstraints = reindex f <$> r1csConstraints,
+        r1csNumVars = r1csNumVars,
+        r1csPublicInputs = g <$> r1csPublicInputs,
+        r1csPrivateInputs = g <$> r1csPrivateInputs,
+        r1csOutputs = g <$> r1csOutputs
+      }
+    where
+      g i = fromMaybe i $ IntMap.lookup i f

--- a/language/src/Circuit/Language/Compile.hs
+++ b/language/src/Circuit/Language/Compile.hs
@@ -147,8 +147,8 @@ freshOutput label = do
     s
       { bsVars =
           (bsVars s)
-            { cvOutputs = IntSet.insert (wireName v) (cvOutputs $ bsVars s)
-            , cvInputsLabels = insertInputBinding label (wireName v) (cvInputsLabels $ bsVars s)
+            { cvOutputs = IntSet.insert (wireName v) (cvOutputs $ bsVars s),
+              cvInputsLabels = insertInputBinding label (wireName v) (cvInputsLabels $ bsVars s)
             }
       }
   pure v

--- a/language/src/Circuit/Language/Compile.hs
+++ b/language/src/Circuit/Language/Compile.hs
@@ -140,14 +140,15 @@ freshPrivateInput label = do
 {-# INLINE freshPrivateInput #-}
 
 -- | Fresh output variables
-freshOutput :: (MonadState (BuilderState f) m) => m Wire
-freshOutput = do
+freshOutput :: (MonadState (BuilderState f) m) => Text -> m Wire
+freshOutput label = do
   v <- OutputWire <$> fresh
   modify $ \s ->
     s
       { bsVars =
           (bsVars s)
             { cvOutputs = IntSet.insert (wireName v) (cvOutputs $ bsVars s)
+            , cvInputsLabels = insertInputBinding label (wireName v) (cvInputsLabels $ bsVars s)
             }
       }
   pure v

--- a/language/src/Circuit/Language/DSL.hs
+++ b/language/src/Circuit/Language/DSL.hs
@@ -100,15 +100,15 @@ boolInput it label = case it of
 
 fieldOutput :: (Hashable f, GaloisField f) => Text -> Signal f f -> ExprM f (Var Wire f f)
 fieldOutput label s = do
-  out <- VarField <$> freshPublicInput label
+  out <- VarField <$> freshOutput label
   compileWithWire out s
 
 fieldsOutput :: (KnownNat n, Hashable f, GaloisField f) => Vector n (Var Wire f f) -> Signal f (Vector n f) -> ExprM f (Vector n (Var Wire f f))
 fieldsOutput vs s = fromJust . SV.toSized <$> compileWithWires (SV.fromSized vs) s
 
 boolOutput :: (Hashable f, GaloisField f) => Text -> Signal f Bool -> ExprM f (Var Wire f Bool)
-boolOutput v s = do
-  out <- VarBool <$> freshPublicInput v
+boolOutput label s = do
+  out <- VarBool <$> freshOutput label
   unsafeCoerce <$> compileWithWire (boolToField out) (boolToField s)
 
 boolsOutput :: (KnownNat n, Hashable f, GaloisField f) => Vector n (Var Wire f Bool) -> Signal f (Vector n Bool) -> ExprM f (Vector n (Var Wire f Bool))


### PR DESCRIPTION
Circom has a very particular order it wants variables to be in, which requires us to relabel variables before using that toolchain. This PR introduces a convenience function for doing that relabling via the `Reindexable` class