### PR TITLE
Bitvector ops

### DIFF
--- a/arithmetic-circuits.cabal
+++ b/arithmetic-circuits.cabal
@@ -131,7 +131,7 @@ test-suite language-tests
 
   hs-source-dirs:     language/test
 
-  ghc-options:        -freverse-errors  -O2 -Wall -main-is Main
+  ghc-options:        -fprof-auto -freverse-errors  -O2 -Wall -main-is Main
   build-depends:
       arithmetic-circuits
     , arithmetic-circuits:language

--- a/arithmetic-circuits.cabal
+++ b/arithmetic-circuits.cabal
@@ -36,7 +36,7 @@ common extensions
     RecordWildCards
 
 common warnings
-  ghc-options: -Wall -Wredundant-constraints -Werror
+  ghc-options: -Wall -Wredundant-constraints
 
 
 common deps
@@ -131,7 +131,7 @@ test-suite language-tests
 
   hs-source-dirs:     language/test
 
-  ghc-options:        -fprof-auto -freverse-errors  -O2 -Wall -main-is Main
+  ghc-options:        -freverse-errors  -O2 -Wall -main-is Main
   build-depends:
       arithmetic-circuits
     , arithmetic-circuits:language

--- a/arithmetic-circuits.cabal
+++ b/arithmetic-circuits.cabal
@@ -31,12 +31,13 @@ common extensions
     GADTs
     LambdaCase
     OverloadedStrings
+    DataKinds
     DeriveAnyClass
     DerivingVia
     RecordWildCards
 
 common warnings
-  ghc-options: -Wall -Wredundant-constraints
+  ghc-options: -Wall -Wredundant-constraints -Werror
 
 
 common deps

--- a/bench/Circuit/Bench.hs
+++ b/bench/Circuit/Bench.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DataKinds #-}
-
 module Circuit.Bench where
 
 import Circuit

--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,5 @@
 tests: True
 benchmarks: True
-profiling: True
 
 packages: .
 

--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,6 @@
 tests: True
 benchmarks: True
+profiling: True
 
 packages: .
 

--- a/circom-compat/app/Main.hs
+++ b/circom-compat/app/Main.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE DataKinds #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
-
 module Main where
 
 import Circuit

--- a/circom-compat/test/Test/R1CS/Circom.hs
+++ b/circom-compat/test/Test/R1CS/Circom.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DataKinds #-}
-
 module Test.R1CS.Circom where
 
 import Data.Binary (decode, decodeFileOrFail, encode)

--- a/circuit/src/Circuit/Arithmetic.hs
+++ b/circuit/src/Circuit/Arithmetic.hs
@@ -82,6 +82,7 @@ wireName :: Wire -> Int
 wireName (InputWire _ _ v) = v
 wireName (IntermediateWire v) = v
 wireName (OutputWire v) = v
+{-# INLINE wireName #-}
 
 -- | An arithmetic circuit with a single multiplication gate.
 data Gate f i

--- a/circuit/test/Test/Circuit/Arithmetic.hs
+++ b/circuit/test/Test/Circuit/Arithmetic.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE DataKinds #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
-
 module Test.Circuit.Arithmetic where
 
 import Circuit.Affine

--- a/language/src/Circuit/Language/Compile.hs
+++ b/language/src/Circuit/Language/Compile.hs
@@ -237,15 +237,8 @@ compile ::
 compile e = do
   case reifyGraph e of
     (xs :|> x) -> do
-      traverse_ compileWithCache xs >> compileWithCache x
+      traverse_ _compile xs >> _compile x
     _ -> panic "empty graph"
-  where
-    compileWithCache (h, x) = do
-      m <- gets bsMemoMap
-      case Map.lookup h m of
-        Just ws -> pure ws
-        Nothing -> _compile (h, x)
-    {-# INLINE compileWithCache #-}
 
 {-# SCC _compile #-}
 _compile ::

--- a/language/src/Circuit/Language/Compile.hs
+++ b/language/src/Circuit/Language/Compile.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE PatternSynonyms #-}
 
 module Circuit.Language.Compile
@@ -15,8 +14,6 @@ module Circuit.Language.Compile
     compileWithWire,
     compileWithWires,
     exprToArithCircuit,
-    compile,
-    addWire,
   )
 where
 

--- a/language/src/Circuit/Language/Compile.hs
+++ b/language/src/Circuit/Language/Compile.hs
@@ -266,6 +266,7 @@ _compile (h, expr) = case expr of
             let f = NVal 0 :: Node Wire f
             _f <- _compile (Hash $ hash f, f) >>= assertSingleSource
             pure $ V.fromList $ shiftList _f n (toList eOuts)
+          UUReverse -> pure $ V.reverse eOuts
           _ -> let f eOut = case op of
                      UUNeg -> AffineSource $ ScalarMul (-1) (addVar eOut)
                      UUNot -> AffineSource $ Add (ConstGate 1) (ScalarMul (-1) (addVar eOut))

--- a/language/src/Circuit/Language/DSL.hs
+++ b/language/src/Circuit/Language/DSL.hs
@@ -38,8 +38,8 @@ module Circuit.Language.DSL
     atIndex,
     updateIndex_,
     truncate_,
-    rotateRight,
-    rotateLeft,
+    rotate_,
+    shift_,
 
     -- * Monoids
     Any_ (..),
@@ -230,6 +230,7 @@ instance (Hashable f, Num f) => Semigroup (XOr_ f) where
 instance (Eq f, Num f, Hashable f) => Monoid (XOr_ f) where
   mempty = XOr_ $ cBool False
 
+
 --------------------------------------------------------------------------------
 
 elem_ ::
@@ -271,30 +272,3 @@ instance (Hashable f, GaloisField f, KnownNat n) => Bundle f ('TVec n 'TBool) wh
   type Unbundled f ('TVec n 'TBool) = Vector n (Signal f 'TBool)
   bundle = bundle_
   unbundle = fmap unsafeCoerce . _unBundle
-
---------------------------------------------------------------------------------
-
-rotateRight ::
-  forall n d a.
-  (KnownNat d) =>
-  (KnownNat n) =>
-  Vector n a ->
-  Finite d ->
-  Vector n a
-rotateRight xs d =
-  fromJust $ SV.fromList $ rotateList (fromIntegral d) $ SV.toList xs
-
-rotateLeft ::
-  forall n d a.
-  (KnownNat d) =>
-  (KnownNat n) =>
-  Vector n a ->
-  Finite d ->
-  Vector n a
-rotateLeft xs d =
-  fromJust $ SV.fromList $ rotateList (negate $ fromIntegral d) $ SV.toList xs
-
-rotateList :: Int -> [a] -> [a]
-rotateList steps x =
-  let n = length x
-   in take n $ drop (steps `mod` n) $ cycle x

--- a/language/src/Circuit/Language/DSL.hs
+++ b/language/src/Circuit/Language/DSL.hs
@@ -1,5 +1,4 @@
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE TypeFamilyDependencies #-}
+{-# LANGUAGE TypeFamilies #-}
 
 -- | Surface language
 module Circuit.Language.DSL

--- a/language/src/Circuit/Language/DSL.hs
+++ b/language/src/Circuit/Language/DSL.hs
@@ -35,8 +35,6 @@ module Circuit.Language.DSL
     compileWithWire,
     split_,
     join_,
-    atIndex,
-    updateIndex_,
     truncate_,
     rotate_,
     shift_,
@@ -56,12 +54,10 @@ import Circuit.Arithmetic (InputType (Private, Public), Wire (..))
 import Circuit.Language.Compile
 import Circuit.Language.Expr
 import Data.Field.Galois (GaloisField)
-import Data.Finite (Finite)
 import Data.Maybe (fromJust)
-import Data.Vector.Sized (Vector, ix)
+import Data.Vector.Sized (Vector)
 import Data.Vector.Sized qualified as SV
 import GHC.TypeNats (type (+))
-import Lens.Micro ((.~), (^.))
 import Protolude
 import Unsafe.Coerce (unsafeCoerce)
 
@@ -159,28 +155,6 @@ boolOutput label s = do
 
 boolsOutput :: (KnownNat n, Hashable f, GaloisField f) => Vector n (Var Wire f 'TBool) -> Signal f ('TVec n 'TBool) -> ExprM f (Vector n (Var Wire f 'TBool))
 boolsOutput vs s = unsafeCoerce <$> fieldsOutput (boolToField <$> vs) (boolToField s)
-
-atIndex ::
-  (Bundle f ('TVec n ty)) =>
-  (Unbundled f (TVec n ty) ~ Vector n (Signal f ty)) =>
-  Finite n ->
-  Signal f ('TVec n ty) ->
-  ExprM f (Signal f ty)
-atIndex i b = do
-  bs <- unbundle b
-  return $ bs ^. ix i
-
-updateIndex_ ::
-  (Bundle f ('TVec n ty)) =>
-  (Unbundled f (TVec n ty) ~ Vector n (Signal f ty)) =>
-  Finite n ->
-  Signal f ty ->
-  Signal f ('TVec n ty) ->
-  ExprM f (Signal f ('TVec n ty))
-updateIndex_ p s v = do
-  bs <- unbundle v
-  let bs' = bs & ix p .~ s
-  return $ bundle bs'
 
 truncate_ ::
   forall f ty n m.

--- a/language/src/Circuit/Language/Expr.hs
+++ b/language/src/Circuit/Language/Expr.hs
@@ -1,9 +1,6 @@
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
 
 module Circuit.Language.Expr
   ( Val (..),

--- a/language/test/Test/Circuit/Expr.hs
+++ b/language/test/Test/Circuit/Expr.hs
@@ -1,8 +1,3 @@
-{-# LANGUAGE DataKinds #-}
-{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
-
-{-# HLINT ignore "Use <$>" #-}
-
 module Test.Circuit.Expr where
 
 import Circuit

--- a/language/test/Test/Circuit/Expr.hs
+++ b/language/test/Test/Circuit/Expr.hs
@@ -99,7 +99,7 @@ prop_evalEqArithEval (ExprWithInputs expr inputs) =
     testInput circuit input =
       let a = evalExpr Map.lookup (Map.mapKeys (InputWire "" Public) input) expr
           b = arithOutput input circuit Map.! (OutputWire 1)
-       in a == V.singleton b
+       in a == Right (V.singleton b)
     arithOutput input circuit =
       evalArithCircuit
         (Map.lookup)

--- a/language/test/Test/Circuit/Expr.hs
+++ b/language/test/Test/Circuit/Expr.hs
@@ -9,6 +9,7 @@ import Circuit
 import Circuit.Language
 import Data.Field.Galois (GaloisField, Prime)
 import Data.Map qualified as Map
+import Data.Vector qualified as V
 import Protolude hiding (Show, show)
 import Test.Tasty.QuickCheck
 import Text.PrettyPrint.Leijen.Text hiding ((<$>))
@@ -98,7 +99,7 @@ prop_evalEqArithEval (ExprWithInputs expr inputs) =
     testInput circuit input =
       let a = evalExpr Map.lookup (Map.mapKeys (InputWire "" Public) input) expr
           b = arithOutput input circuit Map.! (OutputWire 1)
-       in a == b
+       in a == V.singleton b
     arithOutput input circuit =
       evalArithCircuit
         (Map.lookup)

--- a/language/test/Test/Circuit/Lang.hs
+++ b/language/test/Test/Circuit/Lang.hs
@@ -72,7 +72,7 @@ bitIndex :: Finite (NBits Fr) -> ExprM Fr (Expr Wire Fr 'TBool)
 bitIndex i = do
   x <- var_ <$> fieldInput Public "x"
   let bits = split_ x
-  bi <- atIndex i bits
+  let bi = atIndex_  bits i
   void $ boolOutput "out" bi
   pure bi
 
@@ -90,8 +90,8 @@ setAtIndex :: Finite (NBits Fr) -> Bool -> ExprM Fr (Expr Wire Fr 'TField)
 setAtIndex i b = do
   x <- var_ <$> fieldInput Public "x"
   let bits = split_ x
-  bits' <- updateIndex_ i (cBool b) bits
-  let res = join_ bits'
+      bits' = updateAtIndex_ bits i (cBool b) 
+      res = join_ bits'
   void $ fieldOutput "out" res
   pure res
 

--- a/language/test/Test/Circuit/Lang.hs
+++ b/language/test/Test/Circuit/Lang.hs
@@ -269,7 +269,7 @@ propBitVecUnopsProg top op = forAll arbInputs $ \bs ->
       a = intToBitVec $ bitOp $ bitVecToInt bs
       out = fromJust $ sequence $ map (\i -> lookupVar bsVars ("out" <> show @Int i) w) [0 .. 31]
       computed = evalExpr IntMap.lookup input (relabelExpr wireName prog)
-   in map boolToField expected === out .&&. map _fieldToBool out === a .&&. computed === Right (V.fromList (map boolToField expected))
+   in map boolToField expected === out .&&. map _fieldToBool out === a .&&. computed === Right (V.fromList out)
   where
     arbInputs = vectorOf 32 arbitrary
     bitOp = case top of

--- a/language/test/Test/Circuit/Lang.hs
+++ b/language/test/Test/Circuit/Lang.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE NoStarIsType #-}
 

--- a/language/test/Test/Circuit/SHA3.hs
+++ b/language/test/Test/Circuit/SHA3.hs
@@ -32,6 +32,7 @@ import Test.QuickCheck (Arbitrary (..), Property, withMaxSuccess, (===))
 import Test.QuickCheck.Monadic (monadicIO, run)
 import Prelude qualified
 
+{-
 type Fr = Prime 21888242871839275222246405745257275088548364400416034343698204186575808495617
 
 -- | Row major 5x5 matrix of 64 bit values
@@ -72,14 +73,14 @@ theta rows = do
       ps <- paritys
       SV.zipWithM
         xors
-        (rotateRight ps (1 :: Finite 5))
-        (map (flip rotateLeft (1 :: Finite 64)) $ rotateLeft ps (1 :: Finite 5))
+        (rotate ps (-1))
+        (map (flip rotate (-1)) $ rotate ps (-1))
 
 -- | Rho block permutation step
 rho :: SHA3State f -> SHA3State f
-rho = chunk . SV.zipWith (flip rotateLeft) rots . concatVec
+rho = chunk . SV.zipWith (\i n -> rotate_ (-n) i) rots . concatVec
   where
-    rots :: Vector 25 (Finite 64)
+    rots :: Vector 25 Int
     rots =
       Build
         ( 0
@@ -151,7 +152,7 @@ pi_ rows =
 chi :: forall f. (Hashable f, GaloisField f) => SHA3State f -> ExprM f (SHA3State f)
 chi rows = do
   distribute
-    <$> zipWith3M (zipWith3M func) cols (rotateLeft cols (1 :: Finite 5)) (rotateLeft cols (2 :: Finite 5))
+    <$> zipWith3M (zipWith3M func) cols (rotate cols 1) (rotate cols (-2))
   where
     cols = distribute rows
     func :: BitVector f 64 -> BitVector f 64 -> BitVector f 64 -> ExprM f (BitVector f 64)
@@ -376,3 +377,4 @@ _fieldToBool x = x /= 0
 boolToField_ :: Bool -> Fr
 boolToField_ True = 1
 boolToField_ False = 0
+-}

--- a/language/test/Test/Circuit/SHA3.hs
+++ b/language/test/Test/Circuit/SHA3.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}

--- a/language/test/Test/Circuit/Sudoku.hs
+++ b/language/test/Test/Circuit/Sudoku.hs
@@ -122,7 +122,7 @@ spec_sudokuSolver = do
             computed = evalExpr IntMap.lookup (pubInputs `IntMap.union` privInputs) (relabelExpr wireName prog)
         verifier (map snd sol) `shouldBe` True
         (i, out) `shouldBe` (i, Just 1)
-        (i, computed) `shouldBe` (i, V.singleton 1)
+        (i, computed) `shouldBe` (i, Right $ V.singleton 1)
 
 verifier :: [Int] -> Bool
 verifier _input =

--- a/language/test/Test/Circuit/Sudoku.hs
+++ b/language/test/Test/Circuit/Sudoku.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DataKinds #-}
-
 module Test.Circuit.Sudoku where
 
 import Circuit

--- a/language/test/Test/Circuit/Sudoku.hs
+++ b/language/test/Test/Circuit/Sudoku.hs
@@ -16,6 +16,7 @@ import Data.Type.Nat (Nat3, Nat9)
 import Data.Type.Nat qualified as Nat
 import Data.Vec.Lazy (Vec, universe)
 import Data.Vec.Lazy qualified as Vec
+import Data.Vector qualified as V
 import Protolude hiding (head)
 import Test.Hspec (Spec, describe, it, shouldBe)
 
@@ -121,7 +122,7 @@ spec_sudokuSolver = do
             computed = evalExpr IntMap.lookup (pubInputs `IntMap.union` privInputs) (relabelExpr wireName prog)
         verifier (map snd sol) `shouldBe` True
         (i, out) `shouldBe` (i, Just 1)
-        (i, computed) `shouldBe` (i, True)
+        (i, computed) `shouldBe` (i, V.singleton 1)
 
 verifier :: [Int] -> Bool
 verifier _input =


### PR DESCRIPTION
- add bitvector operations to `Expr` language. This actually allows us to define `unbundle` purely
- add `Bits` instance bitvectors
- use the untyped language for circuit evaulation (was getting all kinds of GHC runtime crashes when using the typed evaluator)
- include the circuit evaluation in the test suites. 