### PR TITLE
Add Verify command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ dist*/
 TAGS
 dist-newstyle
 inputs.json
-factors.*
+circuit-output

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ dist*/
 TAGS
 dist-newstyle
 inputs.json
-circuit-output
+factors.*

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist-newstyle
 inputs.json
 circuit-output
 factors.*
+factors-inputs-template.json

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ TAGS
 dist-newstyle
 inputs.json
 circuit-output
+factors.*

--- a/arithmetic-circuits.cabal
+++ b/arithmetic-circuits.cabal
@@ -114,6 +114,7 @@ library circom-compat
       arithmetic-circuits
     , arithmetic-circuits:language
     , bytestring
+    , errors
     , optparse-applicative
     , vector
 

--- a/arithmetic-circuits.cabal
+++ b/arithmetic-circuits.cabal
@@ -114,7 +114,6 @@ library circom-compat
       arithmetic-circuits
     , arithmetic-circuits:language
     , bytestring
-    , directory
     , optparse-applicative
     , vector
 

--- a/bench/Circuit/Bench.hs
+++ b/bench/Circuit/Bench.hs
@@ -20,14 +20,14 @@ benchmarks =
       bench "1_000_000" $ whnf largeMult (Proxy @1_000_000)
     ]
 
-largeMult :: KnownNat n => Proxy n -> IO Fr
+largeMult :: (KnownNat n) => Proxy n -> IO Fr
 largeMult n =
   let BuilderState {bsVars, bsCircuit} = snd $ runCircuitBuilder (program n)
       inputs =
         assignInputs bsVars $ Map.singleton "x" (Array $ map fromIntegral [1 .. natVal n])
       w = altSolve bsCircuit inputs
       res = fromMaybe (panic "output not found") $ lookupVar bsVars "out" w
-  in pure res
+   in pure res
 
 program :: forall n. (KnownNat n) => Proxy n -> ExprM Fr (Var Wire Fr 'TField)
 program _ = do

--- a/circom-compat/app/Main.hs
+++ b/circom-compat/app/Main.hs
@@ -16,9 +16,11 @@ program = do
   a <- var_ <$> fieldInput Private "a"
   b <- var_ <$> fieldInput Private "b"
   n <- var_ <$> fieldInput Public "n"
-  let cs =
+  zs <- map var_ <$> fieldInputs @5 Public "zs"
+  let s = unAdd_ $ foldMap Add_ zs
+      cs =
         [ neq_ n a,
           neq_ n b,
-          eq_ n (a * b)
+          eq_ n (a * b + s)
         ]
   boolOutput "out" $ unAnd_ $ foldMap And_ cs

--- a/circom-compat/src/Circom/CLI.hs
+++ b/circom-compat/src/Circom/CLI.hs
@@ -2,7 +2,7 @@ module Circom.CLI (defaultMain) where
 
 import Circom.R1CS (r1csToCircomR1CS)
 import Circom.Solver (CircomProgram (..), mkCircomProgram, nativeGenWitness)
-import Circuit.Arithmetic (CircuitVars (cvInputsLabels, cvOutputs), InputBindings (labelToVar), restrictVars)
+import Circuit.Arithmetic (CircuitVars (..), InputBindings (labelToVar), restrictVars)
 import Circuit.Dataflow qualified as DataFlow
 import Circuit.Dot (arithCircuitToDot)
 import Circuit.Language.Compile (BuilderState (..), ExprM, runCircuitBuilder)
@@ -127,7 +127,9 @@ defaultMain progName program = do
       encodeFile (r1csFilePath outDir) r1cs
       encodeFile (binFilePath outDir) prog
       when (coGenInputsTemplate compilerOpts) $ do
-        let inputsTemplate = map (const A.Null) $ labelToVar $ cvInputsLabels $ cpVars prog
+        let vars = cpVars prog
+            inputsOnly = cvInputsLabels $ restrictVars vars (cvPrivateInputs vars `IntSet.union` cvPublicInputs vars)
+            inputsTemplate = map (const A.Null) $ labelToVar inputsOnly
         A.encodeFile (inputsTemplateFilePath outDir) inputsTemplate
       when (coIncludeJson compilerOpts) $ do
         A.encodeFile (r1csFilePath outDir <> ".json") (map fromP r1cs)

--- a/circom-compat/src/Circom/CLI.hs
+++ b/circom-compat/src/Circom/CLI.hs
@@ -11,12 +11,13 @@ import Data.Aeson qualified as A
 import Data.Binary (decodeFile, encodeFile)
 import Data.Field.Galois (Prime, PrimeField (fromP))
 import Data.IntSet qualified as IntSet
+import Data.Map qualified as Map
 import Data.Text qualified as Text
+import Data.Text.Read (decimal, hexadecimal)
 import GHC.TypeNats (SNat, withKnownNat, withSomeSNat)
 import Options.Applicative (CommandFields, Mod, Parser, ParserInfo, command, execParser, fullDesc, header, help, helper, hsubparser, info, long, progDesc, showDefault, strOption, switch, value)
 import Protolude
 import R1CS (R1CS, Witness, isValidWitness, toR1CS)
-import Data.Text.Read (decimal, hexadecimal)
 import Prelude (MonadFail (fail))
 
 data GlobalOpts = GlobalOpts
@@ -138,8 +139,8 @@ solveOptsParser progName =
       )
 
 data VerifyOpts = VerifyOpts
-  { voR1CSFile :: FilePath
-  , voWitnessFile :: FilePath
+  { voR1CSFile :: FilePath,
+    voWitnessFile :: FilePath
   }
 
 verifyOptsParser :: Text -> Parser VerifyOpts
@@ -190,11 +191,11 @@ defaultMain progName program = do
     Solve solveOpts -> do
       inputs <- do
         mInputs <- decodeFileStrict (soInputsFile solveOpts)
-        maybe (panic "Failed to decode inputs") (pure . map (fromInteger @f . unFieldElem)) mInputs
+        maybe (panic "Failed to decode inputs") (pure . mkInputs @f) mInputs
       let binFilePath = soCircuitBinFile solveOpts
-      circuit <- decodeFile binFilePath 
+      circuit <- decodeFile binFilePath
       let wtns = nativeGenWitness circuit inputs
-          wtnsFilePath =  soWitnessFile solveOpts
+          wtnsFilePath = soWitnessFile solveOpts
       encodeFile wtnsFilePath wtns
       when (soIncludeJson solveOpts) $ do
         A.encodeFile (wtnsFilePath <> ".json") (map fromP wtns)
@@ -234,6 +235,8 @@ optimize opts =
            in mkCircomProgram newVars newCircuit
         else mempty
 
+--------------------------------------------------------------------------------
+
 newtype FieldElem = FieldElem {unFieldElem :: Integer} deriving newtype (Eq, Ord, Enum, Num, Real, Integral)
 
 instance A.FromJSON FieldElem where
@@ -246,3 +249,24 @@ instance A.FromJSON FieldElem where
             then pure a
             else fail $ "FieldElem parser failed to consume all input: " <> Text.unpack rest
     _ -> FieldElem <$> A.parseJSON v
+
+data Input
+  = Simple FieldElem
+  | Multiple [FieldElem]
+
+instance A.FromJSON Input where
+  parseJSON v = case v of
+    A.Array as -> Multiple . toList <$> traverse A.parseJSON as
+    _ -> Simple <$> A.parseJSON v
+
+newtype Inputs = Inputs (Map Text Input) deriving newtype (A.FromJSON)
+
+mkInputs :: forall f. (PrimeField f) => Inputs -> Map Text f
+mkInputs (Inputs m) =
+  let f (label, input) = case input of
+        Simple a -> [(label, fromInteger @f . unFieldElem $ a)]
+        Multiple as -> zipWith (g label) [0 ..] as
+   in Map.fromList . concatMap f . Map.toList $ m
+  where
+    g l (idx :: Int) a =
+      (l <> "[" <> show idx <> "]", fromInteger @f . unFieldElem $ a)

--- a/circom-compat/src/Circom/R1CS.hs
+++ b/circom-compat/src/Circom/R1CS.hs
@@ -21,7 +21,7 @@ where
 import Circuit (CircuitVars (..))
 import Data.Aeson (ToJSON)
 import Data.Binary (Binary (..), Get, Put)
-import Data.Binary.Get (getInt32le, getInt64le, getWord32le, getWord64le, lookAhead, skip, runGet)
+import Data.Binary.Get (getInt32le, getInt64le, getWord32le, getWord64le, lookAhead, runGet, skip)
 import Data.Binary.Put (putInt32le, putLazyByteString, putWord32le, putWord64le, runPut)
 import Data.ByteString.Lazy qualified as LBS
 import Data.Field.Galois (GaloisField (char), PrimeField, fromP)

--- a/circom-compat/src/Circom/Solver.hs
+++ b/circom-compat/src/Circom/Solver.hs
@@ -167,7 +167,7 @@ _setInputSignal env@(ProgramEnv {peCircuit, peInputsSize, peCircuitVars}) stRef 
   st <- readIORef stRef
   let Inputs inputs = psInputs st
   let h = mkFNV msb lsb
-      v = fromMaybe (panic $ "Hash not found: " <> show h) $ Map.lookup (h,i) (labelToVar $ cvInputsLabels peCircuitVars)
+      v = fromMaybe (panic $ "Hash not found: " <> show h) $ Map.lookup (h, i) (labelToVar $ cvInputsLabels peCircuitVars)
   newInput <- fromInteger <$> readBuffer env stRef
   let newInputs = IntMap.insert v newInput inputs
   writeIORef stRef $

--- a/circom-compat/src/Circom/Solver.hs
+++ b/circom-compat/src/Circom/Solver.hs
@@ -163,13 +163,13 @@ _setInputSignal ::
   Word32 ->
   Int ->
   IO ()
-_setInputSignal env@(ProgramEnv {peCircuit, peInputsSize, peCircuitVars}) stRef msb lsb _ = do
+_setInputSignal env@(ProgramEnv {peCircuit, peInputsSize, peCircuitVars}) stRef msb lsb i = do
   st <- readIORef stRef
   let Inputs inputs = psInputs st
   let h = mkFNV msb lsb
-      i = fromMaybe (panic $ "Hash not found: " <> show h) $ Map.lookup h (labelToVar $ cvInputsLabels peCircuitVars)
+      v = fromMaybe (panic $ "Hash not found: " <> show h) $ Map.lookup (h,i) (labelToVar $ cvInputsLabels peCircuitVars)
   newInput <- fromInteger <$> readBuffer env stRef
-  let newInputs = IntMap.insert i newInput inputs
+  let newInputs = IntMap.insert v newInput inputs
   writeIORef stRef $
     if IntMap.size newInputs == peInputsSize
       then
@@ -206,7 +206,7 @@ nativeGenWitness ::
   forall f.
   (PrimeField f) =>
   CircomProgram f ->
-  Map Text f ->
+  Map Text (VarType f) ->
   CircomWitness f
 nativeGenWitness CircomProgram {cpVars = vars, cpCircuit = circ} inputs =
   let initAssignments = assignInputs vars inputs

--- a/circom-compat/src/Circom/Solver.hs
+++ b/circom-compat/src/Circom/Solver.hs
@@ -88,16 +88,16 @@ mkProgramEnv ::
   ProgramEnv f
 mkProgramEnv CircomProgram {cpVars = vars, cpCircuit = circ} =
   let vs = relabel hashText vars
-  in ProgramEnv
-    { peFieldSize = FieldSize 32,
-      peRawPrime = toInteger $ char (1 :: f),
-      peVersion = 2,
-      peInputsSize = IntSet.size $ cvPrivateInputs vars <> cvPublicInputs vars,
-      peWitnessSize = IntSet.size $ IntSet.insert oneVar $ cvVars vars,
-      peCircuit = circ,
-      peSignalSizes = inputSizes (cvInputsLabels vs),
-      peCircuitVars = vs
-    }
+   in ProgramEnv
+        { peFieldSize = FieldSize 32,
+          peRawPrime = toInteger $ char (1 :: f),
+          peVersion = 2,
+          peInputsSize = IntSet.size $ cvPrivateInputs vars <> cvPublicInputs vars,
+          peWitnessSize = IntSet.size $ IntSet.insert oneVar $ cvVars vars,
+          peCircuit = circ,
+          peSignalSizes = inputSizes (cvInputsLabels vs),
+          peCircuitVars = vs
+        }
 
 data ProgramState f = ProgramState
   { psInputs :: Inputs f,
@@ -154,10 +154,9 @@ _getInputSize = peInputsSize
 
 -- we dont (yet) support multiple values (e.g. arrays) for signal values
 _getInputSignalSize :: ProgramEnv f -> Word32 -> Word32 -> IO Int
-_getInputSignalSize ProgramEnv {peSignalSizes} msb lsb = 
+_getInputSignalSize ProgramEnv {peSignalSizes} msb lsb =
   let h = mkFNV msb lsb
-  in pure $ fromMaybe 0 $ Map.lookup h peSignalSizes
-  
+   in pure $ fromMaybe 0 $ Map.lookup h peSignalSizes
 
 -- we ignore the last arugment because our signals don't have indices, only names
 _setInputSignal ::

--- a/circuit/src/Circuit/Arithmetic.hs
+++ b/circuit/src/Circuit/Arithmetic.hs
@@ -50,7 +50,6 @@ import Text.PrettyPrint.Leijen.Text as PP
     vcat,
     (<+>),
   )
-import qualified Data.Aeson as A
 
 data InputType = Public | Private deriving (Show, Eq, Ord, Generic, NFData)
 
@@ -389,14 +388,6 @@ data VarType f = Simple f | Array [f]
 instance Functor VarType where
   fmap f (Simple a) = Simple (f a)
   fmap f (Array as) = Array (map f as)
-
-instance A.FromJSON f => A.FromJSON (VarType f) where
-  parseJSON (A.Array as) = Array . toList <$> traverse A.parseJSON as
-  parseJSON a = Simple <$> A.parseJSON a
-
-instance A.ToJSON f => A.ToJSON (VarType f) where
-  toJSON (Simple a) = A.toJSON a
-  toJSON (Array as) = A.toJSON as
 
 assignInputs :: forall label f. (Ord label) => CircuitVars label -> Map label (VarType f) -> IntMap f
 assignInputs CircuitVars {..} inputs =

--- a/circuit/src/Circuit/Arithmetic.hs
+++ b/circuit/src/Circuit/Arithmetic.hs
@@ -15,7 +15,7 @@ module Circuit.Arithmetic
     CircuitVars (..),
     relabel,
     collectCircuitVars,
-    VarType(..),
+    VarType (..),
     assignInputs,
     lookupVar,
     lookupArrayVars,
@@ -392,29 +392,29 @@ instance Functor VarType where
 assignInputs :: forall label f. (Ord label) => CircuitVars label -> Map label (VarType f) -> IntMap f
 assignInputs CircuitVars {..} inputs =
   let is :: Map (label, Int) f
-      is = 
+      is =
         let f (label, i) = case i of
               Simple a -> [((label, 0), a)]
-              Array as -> zipWith (\idx a -> ((label, idx), a)) [0..] as 
-        in Map.fromList $ concatMap f $ Map.toList inputs
-  in IntMap.mapMaybe (\label -> Map.lookup label is) (varToLabel cvInputsLabels)
+              Array as -> zipWith (\idx a -> ((label, idx), a)) [0 ..] as
+         in Map.fromList $ concatMap f $ Map.toList inputs
+   in IntMap.mapMaybe (\label -> Map.lookup label is) (varToLabel cvInputsLabels)
 
 lookupVar :: (Ord label) => CircuitVars label -> label -> IntMap f -> Maybe f
 lookupVar vs label sol = do
   let labelBindings = labelToVar $ cvInputsLabels vs
-  var <- Map.lookup (label,0) labelBindings
+  var <- Map.lookup (label, 0) labelBindings
   IntMap.lookup var sol
 
 lookupArrayVars :: (Ord label) => CircuitVars label -> label -> IntMap f -> Maybe [f]
 lookupArrayVars vs label sol = do
   let labelBindings :: [Int]
-      labelBindings = 
-        map snd $ 
-          sortOn (snd . fst) $ 
-          filter (\a -> fst (fst a) == label) $ 
-          Map.toList $ 
-          labelToVar $ 
-          cvInputsLabels vs
+      labelBindings =
+        map snd $
+          sortOn (snd . fst) $
+            filter (\a -> fst (fst a) == label) $
+              Map.toList $
+                labelToVar $
+                  cvInputsLabels vs
   traverse (flip IntMap.lookup sol) labelBindings
 
 booleanWires :: ArithCircuit f -> Set Wire

--- a/circuit/src/Circuit/Arithmetic.hs
+++ b/circuit/src/Circuit/Arithmetic.hs
@@ -23,6 +23,7 @@ module Circuit.Arithmetic
     nGates,
     InputBindings (..),
     insertInputBinding,
+    inputSizes,
     Reindexable (..),
     restrictVars,
   )
@@ -50,6 +51,7 @@ import Text.PrettyPrint.Leijen.Text as PP
     vcat,
     (<+>),
   )
+import Protolude.Unsafe (unsafeHead)
 
 data InputType = Public | Private deriving (Show, Eq, Ord, Generic, NFData)
 
@@ -488,6 +490,13 @@ restrictInputBindings s InputBindings {..} =
     { labelToVar = Map.filter (\a -> a `IntSet.member` s) labelToVar,
       varToLabel = IntMap.restrictKeys varToLabel s
     }
+
+inputSizes :: (Ord label) => InputBindings label -> Map label Int
+inputSizes InputBindings {..} =
+  Map.fromList $
+    map (\a -> (fst $ unsafeHead a, length a)) $
+      groupBy (\a b -> fst a == fst b) $
+        Map.keys labelToVar
 
 --------------------------------------------------------------------------------
 

--- a/circuit/src/Circuit/Arithmetic.hs
+++ b/circuit/src/Circuit/Arithmetic.hs
@@ -81,7 +81,7 @@ instance Pretty Wire where
     let a = case t of
           Public -> "pub"
           Private -> "priv"
-        suffix = if Text.null label then "" else "_" <> label <> "[" <> show offset <> "]"
+        suffix = if Text.null label then "" else "_" <> label <> "_" <> show offset
      in text (a <> "_input_") <> pretty v <> pretty suffix
   pretty (IntermediateWire v) = text "imm_" <> pretty v
   pretty (OutputWire v) = text "output_" <> pretty v

--- a/circuit/src/Circuit/Arithmetic.hs
+++ b/circuit/src/Circuit/Arithmetic.hs
@@ -42,6 +42,7 @@ import Data.Map qualified as Map
 import Data.Set qualified as Set
 import Data.Text qualified as Text
 import Protolude
+import Protolude.Unsafe (unsafeHead)
 import Text.PrettyPrint.Leijen.Text as PP
   ( Pretty (..),
     hsep,
@@ -51,7 +52,6 @@ import Text.PrettyPrint.Leijen.Text as PP
     vcat,
     (<+>),
   )
-import Protolude.Unsafe (unsafeHead)
 
 data InputType = Public | Private deriving (Show, Eq, Ord, Generic, NFData)
 

--- a/circuit/src/R1CS.hs
+++ b/circuit/src/R1CS.hs
@@ -141,7 +141,7 @@ validateWitness (Witness w) (R1CS {r1csConstraints}) =
     w' = IntMap.insert oneVar 1 w
     satisfiesR1C (R1C (a, b, c)) = substitute a w' * substitute b w' == substitute c w'
 
-isValidWitness :: (Eq f, Num f) => Witness f -> R1CS f -> Bool
+isValidWitness :: forall f. (Eq f, Num f) => Witness f -> R1CS f -> Bool
 isValidWitness w r1cs = isRight $ validateWitness w r1cs
 
 toR1CS :: (Num f) => CircuitVars l -> ArithCircuit f -> R1CS f

--- a/circuit/test/Test/Circuit/Arithmetic.hs
+++ b/circuit/test/Test/Circuit/Arithmetic.hs
@@ -23,7 +23,7 @@ arbVars :: [Int] -> [Int] -> [Gen (AffineCircuit f Wire)]
 arbVars inputs mids =
   varInps inputs ++ varMids (mids \\ inputs)
   where
-    varInps _inputs = [Var . InputWire "" Public <$> elements _inputs]
+    varInps _inputs = [Var . InputWire ("", 0) Public <$> elements _inputs]
     varMids [] = []
     varMids ms@(_ : _) = [Var . IntermediateWire <$> elements ms]
 
@@ -144,7 +144,7 @@ prop_equivalentSolver (ArithCircuitWithInput program inputs) =
 
 prop_basicMultiplication :: (Fr, Fr) -> Bool
 prop_basicMultiplication (a, b) =
-  let c = ArithCircuit [Mul (Var (InputWire "" Public 1)) (Var (InputWire "" Public 2)) (OutputWire 3)]
+  let c = ArithCircuit [Mul (Var (InputWire ("", 0) Public 1)) (Var (InputWire ("", 0) Public 2)) (OutputWire 3)]
       inputs = IntMap.fromList [(1, a), (2, b)]
       vars = collectCircuitVars c
       solution = solve vars c inputs
@@ -154,8 +154,8 @@ prop_complexMultiplication :: (Fr, Fr, Fr, Fr) -> Bool
 prop_complexMultiplication (a, b, c, d) =
   let circuit =
         ArithCircuit
-          [ Mul (Var (InputWire "" Public 1)) (Var (InputWire "" Public 2)) (OutputWire 3),
-            Mul (Var (InputWire "" Public 4)) (Var (InputWire "" Public 5)) (OutputWire 6),
+          [ Mul (Var (InputWire ("",0) Public 1)) (Var (InputWire ("", 0) Public 2)) (OutputWire 3),
+            Mul (Var (InputWire ("",0) Public 4)) (Var (InputWire ("", 0) Public 5)) (OutputWire 6),
             Mul (Var (OutputWire 3)) (Var (OutputWire 6)) (OutputWire 7)
           ]
       inputs = IntMap.fromList [(1, a), (2, b), (4, c), (5, d)]
@@ -167,9 +167,9 @@ prop_division :: (Fr, Fr) -> Bool
 prop_division (a, b) =
   let circuit =
         ArithCircuit
-          [ Mul (Var (InputWire "" Public 1)) (Var (InputWire "" Public 5)) (IntermediateWire 3),
+          [ Mul (Var (InputWire ("", 0) Public 1)) (Var (InputWire ("", 0) Public 5)) (IntermediateWire 3),
             Mul (ConstGate 1) (ConstGate 1) (IntermediateWire 4),
-            Mul (Var (InputWire "" Public 2)) (Var (IntermediateWire 5)) (OutputWire 4)
+            Mul (Var (InputWire ("", 0) Public 2)) (Var (IntermediateWire 5)) (OutputWire 4)
           ]
       inputs = IntMap.fromList [(1, a), (2, b)]
       vars = collectCircuitVars circuit
@@ -183,7 +183,7 @@ prop_bitSummingForward :: Fr -> Bool
 prop_bitSummingForward a =
   let circuit =
         ArithCircuit
-          [ Split (InputWire "" Public 1) (OutputWire <$> [2 .. nBits + 1])
+          [ Split (InputWire ("", 0) Public 1) (OutputWire <$> [2 .. nBits + 1])
           ]
       -- forward
       vars = collectCircuitVars circuit

--- a/circuit/test/Test/Circuit/Arithmetic.hs
+++ b/circuit/test/Test/Circuit/Arithmetic.hs
@@ -154,8 +154,8 @@ prop_complexMultiplication :: (Fr, Fr, Fr, Fr) -> Bool
 prop_complexMultiplication (a, b, c, d) =
   let circuit =
         ArithCircuit
-          [ Mul (Var (InputWire ("",0) Public 1)) (Var (InputWire ("", 0) Public 2)) (OutputWire 3),
-            Mul (Var (InputWire ("",0) Public 4)) (Var (InputWire ("", 0) Public 5)) (OutputWire 6),
+          [ Mul (Var (InputWire ("", 0) Public 1)) (Var (InputWire ("", 0) Public 2)) (OutputWire 3),
+            Mul (Var (InputWire ("", 0) Public 4)) (Var (InputWire ("", 0) Public 5)) (OutputWire 6),
             Mul (Var (OutputWire 3)) (Var (OutputWire 6)) (OutputWire 7)
           ]
       inputs = IntMap.fromList [(1, a), (2, b), (4, c), (5, d)]

--- a/language/src/Circuit/Language/Compile.hs
+++ b/language/src/Circuit/Language/Compile.hs
@@ -110,44 +110,47 @@ imm = IntermediateWire <$> fresh
 {-# INLINE imm #-}
 
 -- | Fresh input variables
-freshPublicInput :: (MonadState (BuilderState f) m) => Text -> m Wire
-freshPublicInput label = do
-  v <- InputWire label Public <$> fresh
+freshPublicInput :: (MonadState (BuilderState f) m) => Text -> Int -> m Wire
+freshPublicInput label offset = do
+  let l = (label, offset)
+  v <- InputWire l Public <$> fresh
   modify $ \s ->
     s
       { bsVars =
           (bsVars s)
             { cvPublicInputs = IntSet.insert (wireName v) (cvPublicInputs $ bsVars s),
-              cvInputsLabels = insertInputBinding label (wireName v) (cvInputsLabels $ bsVars s)
+              cvInputsLabels = insertInputBinding l (wireName v) (cvInputsLabels $ bsVars s)
             }
       }
   pure v
 {-# INLINE freshPublicInput #-}
 
-freshPrivateInput :: (MonadState (BuilderState f) m) => Text -> m Wire
-freshPrivateInput label = do
-  v <- InputWire label Private <$> fresh
+freshPrivateInput :: (MonadState (BuilderState f) m) => Text -> Int -> m Wire
+freshPrivateInput label offset = do
+  let l = (label, offset)
+  v <- InputWire l Private <$> fresh
   modify $ \s ->
     s
       { bsVars =
           (bsVars s)
             { cvPrivateInputs = IntSet.insert (wireName v) (cvPrivateInputs $ bsVars s),
-              cvInputsLabels = insertInputBinding label (wireName v) (cvInputsLabels $ bsVars s)
+              cvInputsLabels = insertInputBinding l (wireName v) (cvInputsLabels $ bsVars s)
             }
       }
   pure v
 {-# INLINE freshPrivateInput #-}
 
 -- | Fresh output variables
-freshOutput :: (MonadState (BuilderState f) m) => Text -> m Wire
-freshOutput label = do
+freshOutput :: (MonadState (BuilderState f) m) => Text -> Int -> m Wire
+freshOutput label offset = do
+  let l = (label, offset)
   v <- OutputWire <$> fresh
   modify $ \s ->
     s
       { bsVars =
           (bsVars s)
             { cvOutputs = IntSet.insert (wireName v) (cvOutputs $ bsVars s),
-              cvInputsLabels = insertInputBinding label (wireName v) (cvInputsLabels $ bsVars s)
+              cvInputsLabels = insertInputBinding l (wireName v) (cvInputsLabels $ bsVars s)
             }
       }
   pure v

--- a/language/src/Circuit/Language/DSL.hs
+++ b/language/src/Circuit/Language/DSL.hs
@@ -137,36 +137,44 @@ fieldInput it label =
     Private -> VarField <$> freshPrivateInput label 0
 {-# INLINE fieldInput #-}
 
-fieldInputs :: KnownNat n => InputType -> Text -> ExprM f (Vector n (Var Wire f 'TField))
-fieldInputs it label = 
+fieldInputs :: (KnownNat n) => InputType -> Text -> ExprM f (Vector n (Var Wire f 'TField))
+fieldInputs it label =
   case it of
-    Public -> SV.generateM (\fin -> 
-        let i = fromIntegral fin
-        in VarField <$> freshPublicInput label i
-      )
-    Private -> SV.generateM (\fin -> 
-        let i = fromIntegral fin
-        in VarField <$> freshPrivateInput label i
-      )
+    Public ->
+      SV.generateM
+        ( \fin ->
+            let i = fromIntegral fin
+             in VarField <$> freshPublicInput label i
+        )
+    Private ->
+      SV.generateM
+        ( \fin ->
+            let i = fromIntegral fin
+             in VarField <$> freshPrivateInput label i
+        )
 {-# INLINE fieldInputs #-}
 
 boolInput :: InputType -> Text -> ExprM f (Var Wire f 'TBool)
 boolInput it label = case it of
-  Public -> VarBool <$> freshPublicInput label 0 
+  Public -> VarBool <$> freshPublicInput label 0
   Private -> VarBool <$> freshPrivateInput label 0
 {-# INLINE boolInput #-}
 
-boolInputs :: KnownNat n => InputType -> Text -> ExprM f (Vector n (Var Wire f 'TBool))
-boolInputs it label = 
+boolInputs :: (KnownNat n) => InputType -> Text -> ExprM f (Vector n (Var Wire f 'TBool))
+boolInputs it label =
   case it of
-    Public -> SV.generateM (\fin -> 
-        let i = fromIntegral fin
-        in VarBool <$> freshPublicInput label i
-      )
-    Private -> SV.generateM (\fin -> 
-        let i = fromIntegral fin
-        in VarBool <$> freshPrivateInput label i
-      )
+    Public ->
+      SV.generateM
+        ( \fin ->
+            let i = fromIntegral fin
+             in VarBool <$> freshPublicInput label i
+        )
+    Private ->
+      SV.generateM
+        ( \fin ->
+            let i = fromIntegral fin
+             in VarBool <$> freshPrivateInput label i
+        )
 {-# INLINE boolInputs #-}
 
 fieldOutput :: (Hashable f, GaloisField f) => Text -> Signal f 'TField -> ExprM f (Var Wire f 'TField)
@@ -175,16 +183,19 @@ fieldOutput label s = do
   compileWithWire out s
 {-# INLINE fieldOutput #-}
 
-fieldOutputs :: forall n f.
-  (KnownNat n, Hashable f, GaloisField f) => 
-  Text -> 
-  Signal f ('TVec n 'TField) -> 
+fieldOutputs ::
+  forall n f.
+  (KnownNat n, Hashable f, GaloisField f) =>
+  Text ->
+  Signal f ('TVec n 'TField) ->
   ExprM f (Vector n (Var Wire f 'TField))
 fieldOutputs label s = do
-  vs <- SV.generateM @n (\fin -> 
+  vs <-
+    SV.generateM @n
+      ( \fin ->
           let i = fromIntegral fin
-          in VarField <$> freshOutput label i
-        )
+           in VarField <$> freshOutput label i
+      )
   fromJust . SV.toSized <$> compileWithWires (SV.fromSized vs) s
 
 boolOutput :: forall f. (Hashable f, GaloisField f) => Text -> Signal f 'TBool -> ExprM f (Var Wire f 'TBool)
@@ -193,19 +204,22 @@ boolOutput label s = do
   unsafeCoerce <$> compileWithWire (boolToField @(Var Wire f 'TBool) out) (boolToField s)
 {-# INLINE boolOutput #-}
 
-boolOutputs :: 
-  forall n f. 
-  (KnownNat n, Hashable f, GaloisField f) => 
+boolOutputs ::
+  forall n f.
+  (KnownNat n, Hashable f, GaloisField f) =>
   Text ->
-  Signal f ('TVec n 'TBool) -> 
+  Signal f ('TVec n 'TBool) ->
   ExprM f (Vector n (Var Wire f 'TBool))
 boolOutputs label s = do
-  vs <- SV.generateM @n (\fin -> 
+  vs <-
+    SV.generateM @n
+      ( \fin ->
           let i = fromIntegral fin
-          in VarBool <$> freshOutput label i
-        )
-  out <- fromJust . SV.toSized @n <$> 
-    compileWithWires (SV.fromSized $ map (boolToField @(Var Wire f 'TBool) ) vs) s
+           in VarBool <$> freshOutput label i
+      )
+  out <-
+    fromJust . SV.toSized @n
+      <$> compileWithWires (SV.fromSized $ map (boolToField @(Var Wire f 'TBool)) vs) s
   pure $ unsafeCoerce out
 
 truncate_ ::

--- a/language/src/Circuit/Language/DSL.hs
+++ b/language/src/Circuit/Language/DSL.hs
@@ -27,6 +27,8 @@ module Circuit.Language.DSL
     neq_,
     fieldInput,
     boolInput,
+    fieldInputs,
+    boolInputs,
     fieldOutput,
     boolOutput,
     fieldsOutput,
@@ -134,6 +136,20 @@ fieldInput it label =
     Public -> VarField <$> freshPublicInput label
     Private -> VarField <$> freshPrivateInput label
 {-# INLINE fieldInput #-}
+
+fieldInputs :: (KnownNat n) => InputType -> Text -> ExprM f (Vector n (Var Wire f 'TField))
+fieldInputs it label =
+  SV.generateM $ \fin ->
+    let label' = label <> "[" <> show (toInteger fin) <> "]"
+     in fieldInput it label'
+{-# INLINE fieldInputs #-}
+
+boolInputs :: (KnownNat n) => InputType -> Text -> ExprM f (Vector n (Var Wire f 'TBool))
+boolInputs it label =
+  SV.generateM $ \fin ->
+    let label' = label <> "[" <> show (toInteger fin) <> "]"
+     in boolInput it label'
+{-# INLINE boolInputs #-}
 
 boolInput :: InputType -> Text -> ExprM f (Var Wire f 'TBool)
 boolInput it label = case it of

--- a/language/src/Circuit/Language/DSL.hs
+++ b/language/src/Circuit/Language/DSL.hs
@@ -27,8 +27,6 @@ module Circuit.Language.DSL
     neq_,
     fieldInput,
     boolInput,
-    fieldInputs,
-    boolInputs,
     fieldOutput,
     boolOutput,
     fieldsOutput,
@@ -136,20 +134,6 @@ fieldInput it label =
     Public -> VarField <$> freshPublicInput label
     Private -> VarField <$> freshPrivateInput label
 {-# INLINE fieldInput #-}
-
-fieldInputs :: (KnownNat n) => InputType -> Text -> ExprM f (Vector n (Var Wire f 'TField))
-fieldInputs it label =
-  SV.generateM $ \fin ->
-    let label' = label <> "[" <> show (toInteger fin) <> "]"
-     in fieldInput it label'
-{-# INLINE fieldInputs #-}
-
-boolInputs :: (KnownNat n) => InputType -> Text -> ExprM f (Vector n (Var Wire f 'TBool))
-boolInputs it label =
-  SV.generateM $ \fin ->
-    let label' = label <> "[" <> show (toInteger fin) <> "]"
-     in boolInput it label'
-{-# INLINE boolInputs #-}
 
 boolInput :: InputType -> Text -> ExprM f (Var Wire f 'TBool)
 boolInput it label = case it of

--- a/language/test/Test/Circuit/Expr.hs
+++ b/language/test/Test/Circuit/Expr.hs
@@ -48,7 +48,7 @@ arbExpr numVars size
       oneof $
         [val_ . ValField <$> arbitrary]
           ++ if numVars > 0
-            then [var_ . VarField . InputWire "" Public <$> choose (0, numVars - 1)]
+            then [var_ . VarField . InputWire ("", 0) Public <$> choose (0, numVars - 1)]
             else []
   | otherwise =
       oneof
@@ -92,7 +92,7 @@ prop_evalEqArithEval (ExprWithInputs expr inputs) =
    in all (testInput circuit) inputs
   where
     testInput circuit input =
-      let a = evalExpr Map.lookup (Map.mapKeys (InputWire "" Public) input) expr
+      let a = evalExpr Map.lookup (Map.mapKeys (InputWire ("",0) Public) input) expr
           b = arithOutput input circuit Map.! (OutputWire 1)
        in a == Right (V.singleton b)
     arithOutput input circuit =
@@ -100,7 +100,7 @@ prop_evalEqArithEval (ExprWithInputs expr inputs) =
         (Map.lookup)
         (Map.insert)
         circuit
-        (Map.mapKeys (InputWire "" Public) input)
+        (Map.mapKeys (InputWire ("",0) Public) input)
 
 arbInputVector :: (Arbitrary f) => Int -> Gen (Map Int f)
 arbInputVector numVars = Map.fromList . zip [0 ..] <$> vector numVars

--- a/language/test/Test/Circuit/Expr.hs
+++ b/language/test/Test/Circuit/Expr.hs
@@ -92,7 +92,7 @@ prop_evalEqArithEval (ExprWithInputs expr inputs) =
    in all (testInput circuit) inputs
   where
     testInput circuit input =
-      let a = evalExpr Map.lookup (Map.mapKeys (InputWire ("",0) Public) input) expr
+      let a = evalExpr Map.lookup (Map.mapKeys (InputWire ("", 0) Public) input) expr
           b = arithOutput input circuit Map.! (OutputWire 1)
        in a == Right (V.singleton b)
     arithOutput input circuit =
@@ -100,7 +100,7 @@ prop_evalEqArithEval (ExprWithInputs expr inputs) =
         (Map.lookup)
         (Map.insert)
         circuit
-        (Map.mapKeys (InputWire ("",0) Public) input)
+        (Map.mapKeys (InputWire ("", 0) Public) input)
 
 arbInputVector :: (Arbitrary f) => Int -> Gen (Map Int f)
 arbInputVector numVars = Map.fromList . zip [0 ..] <$> vector numVars

--- a/language/test/Test/Circuit/Lang.hs
+++ b/language/test/Test/Circuit/Lang.hs
@@ -163,13 +163,13 @@ propBoolBinopsProg ::
   (Bool -> Bool -> Bool) ->
   Property
 propBoolBinopsProg top op = forAll arbInputs $ \(bs, bs') ->
-  let 
-      
-      (prog, BuilderState {bsVars, bsCircuit}) = runCircuitBuilder (boolBinopsProg top)
-      input = assignInputs bsVars $ Map.fromList 
-        [ ("x", Array (map boolToField bs))
-        , ("y", Array (map boolToField bs'))
-        ]
+  let (prog, BuilderState {bsVars, bsCircuit}) = runCircuitBuilder (boolBinopsProg top)
+      input =
+        assignInputs bsVars $
+          Map.fromList
+            [ ("x", Array (map boolToField bs)),
+              ("y", Array (map boolToField bs'))
+            ]
       w = solve bsVars bsCircuit input
       expected = map boolToField $ zipWith op bs bs'
       computed = evalExpr IntMap.lookup input (relabelExpr wireName prog)
@@ -202,9 +202,7 @@ propFieldBinopsProg ::
   (Fr -> Fr -> Fr) ->
   Property
 propFieldBinopsProg top op = forAll arbInputs $ \(bs, bs') ->
-  let 
-      
-      (prog, BuilderState {bsVars, bsCircuit}) = runCircuitBuilder (fieldBinopsProg top)
+  let (prog, BuilderState {bsVars, bsCircuit}) = runCircuitBuilder (fieldBinopsProg top)
       input = assignInputs bsVars $ Map.fromList [("x", Array bs), ("y", Array bs')]
       w = solve bsVars bsCircuit input
       expected = zipWith op bs bs'
@@ -243,8 +241,9 @@ propBitVecUnopsProg ::
   Property
 propBitVecUnopsProg top op = forAll arbInputs $ \bs ->
   let (prog, BuilderState {bsVars, bsCircuit}) = runCircuitBuilder (boolUnopsProg top)
-      input = assignInputs bsVars $ 
-        Map.singleton "x" (Array $ map boolToField bs)
+      input =
+        assignInputs bsVars $
+          Map.singleton "x" (Array $ map boolToField bs)
       w = solve bsVars bsCircuit input
       expected = op bs
       a = intToBitVec $ bitOp $ bitVecToInt bs
@@ -252,7 +251,6 @@ propBitVecUnopsProg top op = forAll arbInputs $ \bs ->
    in lookupArrayVars bsVars "out" w == Just (map boolToField expected)
         .&&. computed === Right (V.fromList (map boolToField expected))
         .&&. expected === a
-    
   where
     arbInputs = vectorOf 32 arbitrary
     bitOp = case top of
@@ -286,8 +284,7 @@ propFieldUnopsProg ::
   (Fr -> Fr) ->
   Property
 propFieldUnopsProg top op = forAll arbInputs $ \bs ->
-  let 
-      (prog, BuilderState {bsVars, bsCircuit}) = runCircuitBuilder (fieldUnopsProg top)
+  let (prog, BuilderState {bsVars, bsCircuit}) = runCircuitBuilder (fieldUnopsProg top)
       input = assignInputs bsVars $ Map.singleton "x" (Array bs)
       w = solve bsVars bsCircuit input
       expected = map op bs

--- a/language/test/Test/Circuit/SHA3.hs
+++ b/language/test/Test/Circuit/SHA3.hs
@@ -307,13 +307,9 @@ rotateRight xs i = map ((\idx -> xs ^. SV.ix idx) . (\idx -> fromIntegral $ idx 
 
 sha3Program :: (KnownNat n) => Proxy n -> ExprM Fr (Vector 256 (Var Wire Fr 'TBool))
 sha3Program _ = do
-  bits :: Vector n (Signal f 'TBool) <- SV.generateM $ \i ->
-    var_ <$> boolInput Public ("b_" <> show (toInteger i))
-  let res = sha3_256 $ map bundle_ $ chunk bits
-  outs <- SV.generateM $ \i -> do
-    let label = "out_" <> show (toInteger i)
-    VarBool <$> freshPublicInput label
-  boolsOutput outs res
+  bits <- map var_ <$> boolInputs Public "b"
+  boolOutputs "out" $ 
+    sha3_256 $ map bundle_ $ chunk bits
 
 prop :: forall n n0. (((n + 1) + n0) ~ 25, KnownNat n0, KnownNat ((n + 1) * 64)) => ([Word8] -> [Word8]) -> Int -> Vector n (Vector 64 Bool) -> Property
 prop hashFunc mdlen vec = withMaxSuccess 1 $ monadicIO $ run $ do
@@ -321,17 +317,12 @@ prop hashFunc mdlen vec = withMaxSuccess 1 $ monadicIO $ run $ do
       inputVec = vec `SV.snoc` mkBitVector' @Integer 0x8000000000000006
       inIndices :: [Finite ((n + 1) * 64)]
       inIndices = [minBound .. maxBound]
-      assignments =
-        Map.fromList $
-          map (\i -> ("b_" <> show @Int (fromIntegral i), boolToField_ $ concatVec inputVec `SV.index` i)) inIndices
-  let input =
-        assignInputs shaVars $
-          assignments
+      assignments = Map.singleton "b" $
+          (Array $ map (\i -> boolToField_ $ concatVec inputVec `SV.index` i) inIndices)
+  let input = assignInputs shaVars assignments
   let w = altSolve shaCircuit input
-  let outIndices :: [Finite 256]
-      outIndices = [minBound .. maxBound]
-      res :: [Bool]
-      res = map (\i -> _fieldToBool $ fromJust $ lookupVar shaVars ("out_" <> show (fromIntegral @_ @Int i)) w) outIndices
+  let res :: [Bool]
+      res = map _fieldToBool $ fromJust $ lookupArrayVars shaVars "out" w
   -- let str = reverse $ map unpack $ chunkList 8 $ toList inputVec
   let resStr = take mdlen $ mkOutput res
   let testIn = mkOutput $ toList (concatVec inputVec)
@@ -341,7 +332,7 @@ prop hashFunc mdlen vec = withMaxSuccess 1 $ monadicIO $ run $ do
 mkOutput :: [Bool] -> [Word8]
 mkOutput = map unpack . chunkList 8
 
---
+-- currently unrunnable
 propsha256 :: ArbVec -> Property
 propsha256 (ArbVec v) =
   withMaxSuccess 1 $

--- a/language/test/Test/Circuit/SHA3.hs
+++ b/language/test/Test/Circuit/SHA3.hs
@@ -308,8 +308,10 @@ rotateRight xs i = map ((\idx -> xs ^. SV.ix idx) . (\idx -> fromIntegral $ idx 
 sha3Program :: (KnownNat n) => Proxy n -> ExprM Fr (Vector 256 (Var Wire Fr 'TBool))
 sha3Program _ = do
   bits <- map var_ <$> boolInputs Public "b"
-  boolOutputs "out" $ 
-    sha3_256 $ map bundle_ $ chunk bits
+  boolOutputs "out" $
+    sha3_256 $
+      map bundle_ $
+        chunk bits
 
 prop :: forall n n0. (((n + 1) + n0) ~ 25, KnownNat n0, KnownNat ((n + 1) * 64)) => ([Word8] -> [Word8]) -> Int -> Vector n (Vector 64 Bool) -> Property
 prop hashFunc mdlen vec = withMaxSuccess 1 $ monadicIO $ run $ do
@@ -317,7 +319,8 @@ prop hashFunc mdlen vec = withMaxSuccess 1 $ monadicIO $ run $ do
       inputVec = vec `SV.snoc` mkBitVector' @Integer 0x8000000000000006
       inIndices :: [Finite ((n + 1) * 64)]
       inIndices = [minBound .. maxBound]
-      assignments = Map.singleton "b" $
+      assignments =
+        Map.singleton "b" $
           (Array $ map (\i -> boolToField_ $ concatVec inputVec `SV.index` i) inIndices)
   let input = assignInputs shaVars assignments
   let w = altSolve shaCircuit input

--- a/language/test/Test/Circuit/Sudoku.hs
+++ b/language/test/Test/Circuit/Sudoku.hs
@@ -95,10 +95,10 @@ spec_sudokuSolver = do
       for_ (zip [(0 :: Int) ..] examplePuzzles) $ \(i, b) -> do
         sol <- Map.toAscList <$> solvePuzzle (concat b)
         let pubAssignments =
-              map (first (\a -> "cell_" <> show (fst a) <> show (snd a))) $
+              map (first (\a -> ("cell_" <> show (fst a) <> show (snd a), 0))) $
                 [((_i, j), v) | _i <- [0 .. 8], j <- [0 .. 8], let v = b !! _i !! j]
             privAssignments =
-              map (first (\a -> "private_cell_" <> show (fst a) <> show (snd a))) $
+              map (first (\a -> ("private_cell_" <> show (fst a) <> show (snd a), 0))) $
                 filter (\(_, v) -> v /= 0) sol
             (prog, BuilderState {bsVars, bsCircuit}) = runCircuitBuilder validate
         let pubInputs =


### PR DESCRIPTION
- add a `verify` command to verify the witness against the r1cs file
- when generating the `inputs-template.json` via cli, we don't want to include the outputs in the template
- add an `encoding` cli options to control inputs/outputs encoding (useful for circom integrations that expect random things like this)